### PR TITLE
Add command to get current sessions for server in backend

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -85,6 +85,7 @@ def main(args):
                "enable" : cmds.enableServer,
                "disable" : cmds.disableServer,
                "get-weight" : cmds.getWeight,
+               "sessions" : cmds.getServerSessions,
                "servers" : cmds.listServers,
                "set-weight" : cmds.setWeight,
                "frontends" : cmds.showFrontends,

--- a/haproxy/cmds.py
+++ b/haproxy/cmds.py
@@ -207,3 +207,25 @@ class listServers(baseStat):
                                               "bOut: %s" % outCols[cols['bout']])))
 
         return servers
+
+class getServerSessions(baseStat):
+    """Get Current Sessions for given server"""
+
+    p_args = ["backend", "server"]
+    cmdTxt = "show stat\r\n"
+    helpTxt = "Get current sessions for server in the given backend"
+
+    def getResult(self, res):
+        if self.args['backend'] is None:
+            raise Exception("Need to specify backend")
+        if self.args['server'] is None:
+            raise Exception("Need to specify server")
+        cols = self.getCols(res)
+
+        for line in res.split('\n'):
+            if line.startswith(self.args['backend']):
+            # Lines for server start with the name of the
+            # backend.
+                outCols = line.split(',')
+                if outCols[cols['svname']] == self.args['server']:
+                    return outCols[cols['scur']]


### PR DESCRIPTION
Currently, not all haproxy stats are accessible from haproxyctl. This code adds a new command to query the number of current sessions for a specified server from a specified backend. 

This fits my needs, but perhaps consideration should be given to a more general stats reporter?
