### PR TITLE
cmds.listServers: improve backend matching so that only exact matches…

### DIFF
--- a/haproxy/cmds.py
+++ b/haproxy/cmds.py
@@ -194,9 +194,9 @@ class listServers(baseStat):
         cols = self.getCols(res)
 
         for line in res.split('\n'):
-            if line.startswith(self.args['backend']):
+            if line.startswith(self.args['backend'] + ','):
                 # Lines for server start with the name of the
-                # backend.
+                # backend immediately followed by a comma.
 
                 outCols = line.split(',')
                 if outCols[cols['svname']] != 'BACKEND':


### PR DESCRIPTION
… are returned.

If haproxy has backends such as `foo` and `foo-SSL`,  and the library is used to list the servers within the `foo` backend, unrelated servers in the `foo-SSL` backend are returned. 

This patch tightens the backend string comparison so only backends with an exact match are returned.
